### PR TITLE
Fix core test failures

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -41,8 +41,27 @@ defined('MOODLE_INTERNAL') || die();
  * @param  array $requestparams
  */
 function ltisource_message_handler_before_launch($instance, $endpoint, $requestparams) {
-    $devicetype = core_useragent::get_device_type();
-    if (! ($devicetype === core_useragent::DEVICETYPE_MOBILE || $devicetype === core_useragent::DEVICETYPE_TABLET)) {
-        echo '<script>'.file_get_contents('source/message_handler/js/script_injector.js').'</script>';
+    global $CFG;
+
+    if (defined('AJAX_SCRIPT') && AJAX_SCRIPT) {
+        return;
     }
+
+    if (defined('PHPUNIT_TEST') && PHPUNIT_TEST) {
+        return;
+    }
+
+    $devicetype = core_useragent::get_device_type();
+
+    if ($devicetype === core_useragent::DEVICETYPE_MOBILE) {
+        return;
+    }
+
+    if ($devicetype === core_useragent::DEVICETYPE_TABLET) {
+        return;
+    }
+
+    // This is a hack to inject the script into the page.
+    // Calling js_init_code() does not work here.
+    echo html_writer::script(file_get_contents($CFG->dirroot . '/mod/lti/source/message_handler/js/script_injector.js'));
 }


### PR DESCRIPTION
This resolves the failing `mod_lti` tests.

~~I was unable to check if this plugin works as expected, either before or after the commit.~~

Manual testing was carried out by adding `alert()` calls to the below scripts, and navigating to various LTI activity types and other Moodle pages.

`mod/lti/source/message_handler/js/message_handler.js`
`mod/lti/source/message_handler/js/script_injector.js`


Echo360 activities load the scripts consistently (one of the few activities that do not error out if not correctly configured/authenticated).

Activities that display errors do not seem to load the scripts.

Some other activity types simply display a link to open the activity in a new tab. These activities do not benefit from this plugin as they have no iframes.


The `mod_lti` tests no longer fail:
```
php vendor/bin/phpunit --testsuite mod_lti_testsuite --stop-on-failure
Moodle 4.1.14+ (Build: 20241101), fcff67b915e3765a271100f9f5d3f51043ebfd4b
Php: 7.4.33, pgsql: 16.0 (Debian 16.0-1.pgdg120+1), OS: Linux 6.8.0-49-generic x86_64
PHPUnit 9.5.28 by Sebastian Bergmann and contributors.

...............................................................  63 / 144 ( 43%)
............................................................... 126 / 144 ( 87%)
..................                                              144 / 144 (100%)

Time: 00:38.848, Memory: 135.00 MB

OK (144 tests, 539 assertions)
```